### PR TITLE
Bugfix: Login page not rendering in Korean.

### DIFF
--- a/ko.js
+++ b/ko.js
@@ -1,7 +1,7 @@
 moot.language = {
 
    // the language code
-   $code: 'ko_kr',
+   $code: 'ko',
 
    all: '모든 글', // or alternatively: All
 


### PR DESCRIPTION
My original submission marked the Korean language as 'ko_kr'. Somehow the filename turned into 'ko.js' while the internal $code variable stayed unchanged. The inconsistency resulted in a bug that prevents login page from rendering.
