### PR TITLE
French Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ To create a new localization you need to:
 3. Open the copied files on your text editor and replace the English words with the new language
 4. Send us a pull request
 
-## Fork from moot/language
+### Wait, forking, pull request!?!
 
-This is a fork from moot/language. Only the French translation is updated.
+If forking makes no sense you can just save these files
+
+https://raw.github.com/moot/language/master/en.js
+
+https://raw.github.com/moot/language/master/en.auth.js
+
+on your PC and then proceed with steps 2 and 3 above. Then send the modified files to tero@moot.it
+
 
 ### Testing
 


### PR DESCRIPTION
Hello,

<b>I updated fr.js to be up-to-date with Moot's latest version. I have also fixed a translation.</b>
(This fixes #24)

But there's a little problem with French translation: in French, only the first word is capitalized. For example, it should be <em>"Ne plus surveiller"</em> (unwatch) instead of <em>"Ne Plus Surveiller"</em>.

Thank you!
Léo
