### PR TITLE
update dutch l10n

### DIFF
--- a/nl.js
+++ b/nl.js
@@ -4,17 +4,17 @@ moot.language = {
   $code: 'nl',
 
   /* New stuff */
-  is_private: "Dit forum is niet publiek beschikbaar",
+  is_private: "Dit onderwerp is niet publiek beschikbaar", // hm.. what to call it.. "Community" seems to suck ; revert to "Subject" (onderwerp)..?
   owner_msg: "Uw bericht aan de forum eigenaar... (Optioneel)",
   req_access: "Verzoek toegang",
   req_sent: "Toegang verzoek is verstuurd",
-  or_join: "of <a>word lid</a> to access the community.",
+  or_join: "of <a>lid worden</a>.",
   save_with: "Bespaar 20% middels jaarlijks betaling",
   rem_post: "Verwijder post?",
   is_spam: "Is dit spam?",
 
-  channels: 'Channels',
-  ch_name: 'Channel name',
+  channels: 'Forums', // hm.. what to call it.. "channel" sucks. "subject" (onderwerp) sucks ; revert to forum.. Maybe discussiegroepen?
+  ch_name: 'Forum',// hm.. what to call it.. "channel" sucks. "subject" (onderwerp) sucks ; revert to forum.. Maybe discussiegroep?
   ban:  'Ban gebruiker',
   banned:  'Verbannen',
   ban_acc: 'Verbannen account',


### PR DESCRIPTION
A few changes.. not happy with all changes.. context and usage information could maybe help... 

Is there a possibility of a, fully functional, non-published test/playground environment?
To properly test the l10n I currently have to log in as a one of our clients... even then the string may not be used; depending on the client's account/subscription. Also I do not want to login as the client (asking for passwords is crap and embarrassing) ... ;-)
